### PR TITLE
feat(kno-2228): add Telemetry for monitoring core `Shard.Producer` functionality

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,8 @@ defmodule KinesisClient.Mixfile do
       {:hackney, "~> 1.9"},
       {:jason, "~> 1.1"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
-      {:mox, "~> 1.0", only: :test}
+      {:mox, "~> 1.0", only: :test},
+      {:telemetry, "~> 1.1.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -30,6 +30,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.0", "b44d75e2a6542dcb6acf5d71c32c74ca88960421b6874777f79153bbbbd7dccc", [:mix], [], "hexpm", "52b2871a7515a5ac49b00f214e4165a40724cf99798d8e4a65e4fd64ebd002c1"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
-  "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
This PR adds [telemetry](https://github.com/beam-telemetry/telemetry) as a dep for the lib, and then uses that lib to emit a number of events from `KinesisClient.Stream.Shard.Producer`. Each event includes `shard_id`, `stream_name`, and `app_name` metadata.

The events added:

- `[:kinesis_client, :shard_producer, :started]` — for monitoring when new shard producers come online
- `[:kinesis_client, :shard_producer, :get_records, :start | :stop | :exception]` (trio of events generated via a [span](https://hexdocs.pm/telemetry/telemetry.html#span/3)) — for monitoring calls to Kinesis to get a batch of records; span metadata will include latencies and exception info
- `[:kinesis_client, :shard_producer, :get_records_error]` — for monitoring errors from Kinesis that will trigger a retry
- `[:kinesis_client, :shard_producer, :update_checkpoint, :start | :stop, :exception]` (trio of events generated via a [span](https://hexdocs.pm/telemetry/telemetry.html#span/3)) — for monitoring calls to Kinesis to update the checkpoint when acking messages

Lastly, this PR includes some unit test updates to ensure we cover all edges for the checkpoint update flow.