### PR TITLE
fix(kno-2526): always checkpoint to most recent message

### DIFF
--- a/lib/kinesis_client/error.ex
+++ b/lib/kinesis_client/error.ex
@@ -1,0 +1,3 @@
+defmodule KinesisClient.Error do
+  defexception [:message]
+end

--- a/test/kinesis_client/stream/shard/producer_test.exs
+++ b/test/kinesis_client/stream/shard/producer_test.exs
@@ -231,8 +231,27 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
     test "sorts sequence numbers correctly" do
       assert "12345+10" =
                KinesisClient.Stream.Shard.Producer.get_top_checkpoint(
-                 [%{"Data" => "foo", metadata: %{"SequenceNumber" => "12345+1"}}],
-                 [%{"Data" => "foo", metadata: %{"SequenceNumber" => "12345+10"}}]
+                 [%{metadata: %{"SequenceNumber" => "12345+1"}}],
+                 [%{metadata: %{"SequenceNumber" => "12345+10"}}]
+               )
+    end
+
+    test "returns -1 for incorrectly-formatted messages" do
+      assert "12345+5" =
+               KinesisClient.Stream.Shard.Producer.get_top_checkpoint(
+                 [%{mettadatums: %{"SequenceWhat?" => "12345+1"}}],
+                 [
+                   %{metaverse: %{"NotConforming" => "12345+10"}},
+                   %{is_correct_format?: true, metadata: %{"SequenceNumber" => "12345+5"}}
+                 ]
+               )
+    end
+
+    test "returns -1 for empty lists" do
+      assert "-1" =
+               KinesisClient.Stream.Shard.Producer.get_top_checkpoint(
+                 [],
+                 []
                )
     end
   end

--- a/test/kinesis_client/stream/shard/producer_test.exs
+++ b/test/kinesis_client/stream/shard/producer_test.exs
@@ -109,7 +109,7 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
     assert length(successful) == 5
   end
 
-  test "checkpoints ShardLease with sequence_number when acking a mix of successful and failed messages" do
+  test "checkpoints ShardLease with highest sequence_number when acking a mix of successful and failed messages" do
     opts = producer_opts(status: :started)
     {:ok, producer} = start_supervised({Producer, opts})
     {:ok, consumer} = start_supervised({KinesisClient.TestConsumer, self()})
@@ -133,7 +133,7 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
     {successful_events, failed_events} = Enum.split(events, 2)
 
     expected_latest_checkpoint =
-      successful_events
+      events
       |> Enum.reverse()
       |> hd()
       |> Map.from_struct()
@@ -159,7 +159,7 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
     Process.sleep(500)
   end
 
-  test "does not checkpoint the ShardLease when there are no successful messages" do
+  test "will checkpoint the ShardLease when there are no successful messages" do
     opts = producer_opts(status: :started)
     {:ok, producer} = start_supervised({Producer, opts})
     {:ok, consumer} = start_supervised({KinesisClient.TestConsumer, self()})
@@ -180,9 +180,27 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
     GenStage.sync_subscribe(consumer, to: producer, max_demand: 10, min_demand: 0)
     assert_receive {:consumer_events, events}, 5_000
 
-    # By sending an `ack` message without mocking the `AppState.update_checkpoint/5`
-    # the test will fail if it ever tries to call that function. The expectation is
-    # no call is sent.
+    expected_latest_checkpoint =
+      events
+      |> Enum.reverse()
+      |> hd()
+      |> Map.from_struct()
+      |> get_in([:metadata, "SequenceNumber"])
+
+    AppStateMock
+    |> expect(:update_checkpoint, fn in_app_name,
+                                     in_shard_id,
+                                     in_lease_owner,
+                                     in_checkpoint,
+                                     _opts ->
+      assert in_app_name == opts[:app_name]
+      assert in_shard_id == opts[:shard_id]
+      assert in_lease_owner == opts[:lease_owner]
+      assert in_checkpoint == expected_latest_checkpoint
+
+      :ok
+    end)
+
     send(producer, {:ack, make_ref(), [], events})
 
     # Sleep to allow time for concurrent process to handle the message
@@ -207,6 +225,16 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
     GenStage.sync_subscribe(consumer, to: producer)
 
     refute_receive {:consumer_events, []}, 1_000
+  end
+
+  describe "get_top_checkpoint/2" do
+    test "sorts sequence numbers correctly" do
+      assert "12345+10" =
+               KinesisClient.Stream.Shard.Producer.get_top_checkpoint(
+                 [%{"Data" => "foo", metadata: %{"SequenceNumber" => "12345+1"}}],
+                 [%{"Data" => "foo", metadata: %{"SequenceNumber" => "12345+10"}}]
+               )
+    end
   end
 
   defp producer_opts(overrides \\ []) do


### PR DESCRIPTION
kcl_ex uses Broadway.CallerAcknowledger to acknowledge messages. This sends a set of success messages and a set of failed messages to the producer. The producer is then supposed to sort out what to do about this.

Long-term, this is not the right acknowledger for us to be using, since we just need the highwater mark for all messages in the batch. Broadway's Kafka adapter has a custom acknowledger for this reason.

Short-term, we are patching kcl_ex to exhibit the same behavior as the Kafka producer: Ack all messages and advance to the next set of messages in the shard, regardless of error outcomes. It is up to the consumer to handle_failed according to their appropriate use case. It's not ideal this way because we have to essentially guess which message is the highwater mark using a lexical sort. If we like, we could try and parse the integers (and rewrite the tests to use only integer-based values instead of non-numeric strings) and sort them that way, but these sequence numbers are big enough (`49593554362799306497476712297116585830001273292214763522`) that parsing these constantly seemed risky.

Again, the ideal here would be to have a custom acknowledger that doesn't split the events by success/failure, grabs the last element in the list, and uses that as the highwater mark.