### PR TITLE
feat(kno-4651): gracefully handle Kinesis rate limits on start-up

### DIFF
--- a/test/kinesis_client/stream/coordinator_test.exs
+++ b/test/kinesis_client/stream/coordinator_test.exs
@@ -169,7 +169,7 @@ defmodule KinesisClient.Stream.CoordinatorTest do
     assert Enum.empty?(shards) == false
   end
 
-  test "will retry initialization after :retry_timeout if stream status not ACTIVE" do
+  test "will retry initialization after :retry_timeout if describe stream returns an error" do
     {:ok, _} =
       start_supervised({DynamicSupervisor, [strategy: :one_for_one, name: @supervisor_name]})
 
@@ -177,7 +177,7 @@ defmodule KinesisClient.Stream.CoordinatorTest do
 
     expect(KinesisMock, :describe_stream, fn stream_name, _opts ->
       assert stream_name == @stream_name
-      {:ok, KinesisClient.KinesisResponses.describe_stream(stream_status: "UPDATING")}
+      {:error, :foobar}
     end)
 
     AppStateMock


### PR DESCRIPTION
When starting up a `kcl_ex` supervision tree, the Coordinator GenServer is responsible for fetching shard info for the given stream. Upon success, it starts a Broadway pipeline for each shard and attempts to acquire a lease on the shard to consume data.

However, the initial action to fetch shard info can return a rate limit error. Currently, the Coordinator doesn't handle this response type, which leads to the entire `kcl_ex` supervision tree crashing. It then restarts itself three times (the Supervisor default) and hits the same error again. After the third retry, the tree permanently terminates.

This PR refactors the Coordinator so that it understands errors on the shard fetch step and performs a backoff retry to help alleviate rate limits.

