### PR TITLE
feat: emit 'consumer_name' in telemetry event meta

### DIFF
--- a/lib/kinesis_client/stream.ex
+++ b/lib/kinesis_client/stream.ex
@@ -37,6 +37,7 @@ defmodule KinesisClient.Stream do
     shard_consumer = get_shard_consumer(opts)
 
     shard_args = [
+      consumer_name: opts[:name],
       app_name: opts[:app_name],
       coordinator_name: coordinator_name,
       stream_name: stream_name,

--- a/lib/kinesis_client/stream/shard.ex
+++ b/lib/kinesis_client/stream/shard.ex
@@ -16,6 +16,7 @@ defmodule KinesisClient.Stream.Shard do
     ]
 
     pipeline_opts = [
+      consumer_name: opts[:consumer_name],
       app_name: opts[:app_name],
       shard_id: opts[:shard_id],
       lease_owner: opts[:lease_owner],

--- a/lib/kinesis_client/stream/shard/pipeline.ex
+++ b/lib/kinesis_client/stream/shard/pipeline.ex
@@ -6,6 +6,7 @@ defmodule KinesisClient.Stream.Shard.Pipeline do
 
   def start_link(opts) do
     producer_opts = [
+      consumer_name: opts[:consumer_name],
       app_name: opts[:app_name],
       shard_id: opts[:shard_id],
       lease_owner: opts[:lease_owner],

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -11,6 +11,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
 
   defstruct [
     :kinesis_opts,
+    :consumer_name,
     :stream_name,
     :shard_id,
     :shard_iterator,
@@ -48,6 +49,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
       app_name: opts[:app_name],
       lease_owner: opts[:lease_owner],
       kinesis_opts: opts[:kinesis_opts],
+      consumer_name: opts[:consumer_name],
       stream_name: opts[:stream_name],
       status: opts[:status],
       app_state_opts: Keyword.get(opts, :app_state_opts, []),
@@ -391,6 +393,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
   defp telemetry_meta(%__MODULE__{} = state) do
     %{
       shard_id: state.shard_id,
+      consumer_name: state.consumer_name,
       stream_name: state.stream_name,
       app_name: state.app_name
     }


### PR DESCRIPTION
Passes the `name` config from the top-level (`KinesisClient.Stream`) down to `KinesisClient.Stream.Shard.Producer` so that we can emit it as the `consumer_name` meta attribute in Telemetry events. 