### PR TITLE
feat(kno-4728): emit iterator age metric

### DIFF
--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -272,12 +272,18 @@ defmodule KinesisClient.Stream.Shard.Producer do
       {:ok,
        %{
          "NextShardIterator" => next_iterator,
-         "MillisBehindLatest" => _millis_behind_latest,
+         "MillisBehindLatest" => millis_behind_latest,
          "Records" => records
        }} ->
         new_demand = demand - length(records)
 
         messages = wrap_records(records)
+
+        :telemetry.execute(
+          [:kinesis_client, :shard_producer, :get_records_millis_behind_latest],
+          millis_behind_latest,
+          telemetry_meta(state)
+        )
 
         poll_timer =
           case {records, new_demand} do


### PR DESCRIPTION
I intend to use this telemetry during the clickhouse migration to differentiate between lagging clickhouse and postgres consumers on the same stream.

While this'll create a bunch of new dd metrics, we're still saving costs by not duplicating a bunch of kinesis streams