### PR TITLE
fix: unwrapped values are deprecated - use map instead

### DIFF
--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -281,7 +281,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
 
         :telemetry.execute(
           [:kinesis_client, :shard_producer, :get_records_millis_behind_latest],
-          millis_behind_latest,
+          %{duration: millis_behind_latest},
           telemetry_meta(state)
         )
 


### PR DESCRIPTION
According to https://github.com/beam-telemetry/telemetry/blob/v1.2.1/src/telemetry.erl#L152, providing just a number is deprecated.