### PR TITLE
chore(kno-4620): support shard split/merge functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ SERVICES=kinesis,dynamodb localstack start --host
 ## TODO
 
 - [x] Test shard merges and splits more thoroughly
+- [ ] Adaptively respond to rate limits from Kinesis and GenStage demand so that we don't get throttled
+- [ ] Support [enhanced fanout](https://docs.aws.amazon.com/streams/latest/dev/enhanced-consumers.html) for higher throughput
 - [ ] Support more than just Dynamo for tracking state (e.g. Redis or Postgres)
 - [ ] Consider integrating with Phoenix PubSub so that shard splits and merges can be broadcast to other nodes in the cluster, which can then start/stop the relevant Broadway pipelines.
 - [ ] Consider starting just one Broadway pipeline, and having shards feed into the same pipeline. This would make it operate more like other broadway adapters, since kcl_ex wraps broadway with its own supervision tree.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ When the `KinesisClient.Stream` module starts, it boots up two processes:
 
 1. A Dynamic Supervisor for handling each shard that comes and goes
 2. A [KinesisClient.Stream.Coordinator](lib/kinesis_client/stream/coordinator.ex) process that
-   handles starting shards that are ready to be processed. As shards split and merge, they notify the coordinator process and then shut themselves down. THe coordinator then handles adding those new shards to the pipeline.
+   handles starting shards that are ready to be processed. As shards split and merge, they notify the coordinator process and then shut themselves down. The coordinator then handles adding those new shards to the pipeline.
 3. Each [KinesisClient.Stream.Shard](lib/kinesis_client/stream/shard.ex) supervisor starts a [KinesisClient.Stream.Lease](lib/kinesis_client/stream/shard/lease.ex) to take and maintain exclusive access to the Kinesis shard. By default, it uses the DynamoDB table to record which shard is being processed by which node, and the sequence number of the most recently processed record.
 4. Each `Shard` also starts a [`Pipeline`](lib/kinesis_client/stream/shard/pipeline.ex) process. This sets up the Broadway pipeline that will process the given Shard (although it starts in a `stopped` state, and waits for the `Lease` to send a message indicating it is ready to start processing). The Broadway pipeline producer module is the `KinesisClient.Stream.Shard.Producer` module, which is responsible for fetching records from the Kinesis shard and passing them to the Broadway pipeline. The `Pipeline` delegates the broadway callbacks to the `shard_consumer` module passed in as an option to the `KinesisClient.Stream` module.
 
@@ -109,6 +109,7 @@ SERVICES=kinesis,dynamodb localstack start --host
 - [x] Test shard merges and splits more thoroughly
 - [ ] Adaptively respond to rate limits from Kinesis and GenStage demand so that we don't get throttled
 - [ ] Support [enhanced fanout](https://docs.aws.amazon.com/streams/latest/dev/enhanced-consumers.html) for higher throughput
+- [ ] Support different shard iterator types (https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax) and configuring them in the `KinesisClient.Stream` module
 - [ ] Support more than just Dynamo for tracking state (e.g. Redis or Postgres)
 - [ ] Consider integrating with Phoenix PubSub so that shard splits and merges can be broadcast to other nodes in the cluster, which can then start/stop the relevant Broadway pipelines.
 - [ ] Consider starting just one Broadway pipeline, and having shards feed into the same pipeline. This would make it operate more like other broadway adapters, since kcl_ex wraps broadway with its own supervision tree.

--- a/README.md
+++ b/README.md
@@ -8,18 +8,20 @@ splits and merges.
 By using this library, you get the above functionality without the need to
 deploy a the KCL Multilang Daemon.
 
-
 ## Install
+
 Add this to your dependencies
-```
+
+```elixir
     {:kinesis_client, "~> 0.1.0"},
 ```
+
 and run `mix deps.get`
 
 ## Usage
 
-Stream processing and acknowledgement is handled in a Broadway pipeline. Here's
-a basic configuration:
+Stream processing and acknowledgement is handled in a Broadway pipeline that starts
+for each Kinesis shard. Here's a basic configuration:
 
 ```elixir
 opts = [
@@ -47,6 +49,9 @@ KinesisClient.Stream.start_link(opts)
 `MyShardConsumer` needs to implement the `Broadway` behaviour. You will want to
 start the `KinesisClient.Stream` in your application's supervision tree.
 
+`kcl_ex` will then work out which Kinesis shards ought to be started and then start
+a broadway pipeline for each shard. Once the shard is fully consumed, the pipeline
+will be stopped.
 
 ## Things to keep in mind...
 
@@ -57,23 +62,55 @@ you're at, as opposed to ack-ing individual messages like you can with SQS.
 Increase the number of shards if you want to increase processing throughput.
 
 If increasing the number of shards is not possible or desirable, I would
-recommend fanning out in the `handle_batch/4` callback of your shard consumer. 
+recommend fanning out in the `handle_batch/4` callback of your shard consumer.
 Configuring dead letter queues and partitioning are dependent on your
 application's requirements and the structure of your data.
 
+## How it all works
+
+Kinesis streams are made up of multiple shards. A shard consists of a series of
+ordered records. Each record has a sequence number that is unique within the
+shard. The sequence number is used to keep track of how far an app has processed
+a shard. Kinesis shards can be split and merged to achieve horizontal scale. As
+more writes are applied to the shards in a Kinesis stream, the shards can be
+split to increase the number of shards. This allows for more read and write
+throughput. If the number of shards is too high, they can be merged to reduce
+the number of shards and associated costs.
+
+To consume from a Kinesis stream, you need to keep track of how far you've
+processed each shard. This is done by checkpointing the sequence number of the
+last record you've processed. By default, this library uses a DynamoDB table to keep track of
+this progress. This library also uses the DynamoDB table to keep track of which shards are
+being processed by which nodes when running multiple copies of the same consumer
+in a horizontally scaled system.
+
+### On startup
+
+When the `KinesisClient.Stream` module starts, it boots up two processes:
+
+1. A Dynamic Supervisor for handling each shard that comes and goes
+2. A [KinesisClient.Stream.Coordinator](lib/kinesis_client/stream/coordinator.ex) process that
+   handles starting shards that are ready to be processed. As shards split and merge, they notify the coordinator process and then shut themselves down. THe coordinator then handles adding those new shards to the pipeline.
+3. Each [KinesisClient.Stream.Shard](lib/kinesis_client/stream/shard.ex) supervisor starts a [KinesisClient.Stream.Lease](lib/kinesis_client/stream/shard/lease.ex) to take and maintain exclusive access to the Kinesis shard. By default, it uses the DynamoDB table to record which shard is being processed by which node, and the sequence number of the most recently processed record.
+4. Each `Shard` also starts a [`Pipeline`](lib/kinesis_client/stream/shard/pipeline.ex) process. This sets up the Broadway pipeline that will process the given Shard (although it starts in a `stopped` state, and waits for the `Lease` to send a message indicating it is ready to start processing). The Broadway pipeline producer module is the `KinesisClient.Stream.Shard.Producer` module, which is responsible for fetching records from the Kinesis shard and passing them to the Broadway pipeline. The `Pipeline` delegates the broadway callbacks to the `shard_consumer` module passed in as an option to the `KinesisClient.Stream` module.
 
 ## Development
 
-the tests by default require
-[localstack](https://github.com/localstack/localstack) to be installed and
+The tests by default require [localstack](https://github.com/localstack/localstack) to be installed and
 running. How to do that is outside the scope of this readme, but here's how I'm
 doing it currently:
-```
+
+```shell
 SERVICES=kinesis,dynamodb localstack start --host
 ```
 
 ## TODO
-- [ ] Test shard merges and splits more thoroughly
-- [ ] Implement a work stealing algorithim to help distribute the load among
-  different Elixir nodes processing the same app.
 
+- [x] Test shard merges and splits more thoroughly
+- [ ] Support more than just Dynamo for tracking state (e.g. Redis or Postgres)
+- [ ] Consider integrating with Phoenix PubSub so that shard splits and merges can be broadcast to other nodes in the cluster, which can then start/stop the relevant Broadway pipelines.
+- [ ] Consider starting just one Broadway pipeline, and having shards feed into the same pipeline. This would make it operate more like other broadway adapters, since kcl_ex wraps broadway with its own supervision tree.
+- [ ] Implement a work stealing algorithm to help distribute the load among different Elixir nodes processing the same app.
+  - One option here would be to include a function that decides if a node ought to process a shard or not. This function could be passed in as an option to the `KinesisClient.Stream` module. Such a function could then assign shards to nodes based on a hash of the shard id, for example. Nodes
+    would only start the shard if the function returns true. Multiple nodes could return true, and the
+    leasing mechanism would ensure the shards are only processed by one node at a time.

--- a/lib/kinesis_client/stream.ex
+++ b/lib/kinesis_client/stream.ex
@@ -12,7 +12,7 @@ defmodule KinesisClient.Stream do
 
   ## Options
     * `:stream_name` - Required. The Kinesis Data Stream to process.
-    * `:app_name` - Required.This should be a unique name across all your applications and the DynamodDB
+    * `:app_name` - Required. This should be a unique name across all your applications and the DynamodDB
       tablespace in your AWS region
     * `:name` - The process name. Defaults to `KinesisClient.Stream`.
     * `:max_demand` - The maximum number of records to retrieve from Kinesis. Defaults to 100.

--- a/lib/kinesis_client/stream.ex
+++ b/lib/kinesis_client/stream.ex
@@ -19,10 +19,10 @@ defmodule KinesisClient.Stream do
     * `:aws_region` - AWS region. Will rely on ExAws defaults if not set.
     * `:shard_supervisor` - The child_spec for the Supervisor that monitors the ProcessingPipelines.
       Must implement the DynamicSupervisor behaviour.
-    * `:lease_renew_interval`(optional) - How long (in milliseconds) a lease will be held before a renewal is attempted.
+    * `:lease_renew_interval`(optional) - How long (in milliseconds) a lease will be held before a renewal is attempted. Defaults to 30 seconds
     * `:lease_expiry`(optional) - The lenght of time in milliseconds that least lasts for. If a
       lease is not renewed within this time frame, then that lease is considered expired and can be
-      taken by another process.
+      taken by another process. Defaults to 90 seconds.
   """
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))

--- a/lib/kinesis_client/stream/app_state.ex
+++ b/lib/kinesis_client/stream/app_state.ex
@@ -44,8 +44,8 @@ defmodule KinesisClient.Stream.AppState do
   This indicates that all records for the shard have been processed by the app. `KinesisClient.Stream.Shard`
   processes will not be started for ShardLease's that are completed.
   """
-  def close_shard(app_name, shard_id, opts \\ []),
-    do: adapter(opts).close_shard(app_name, shard_id, opts)
+  def close_shard(app_name, shard_id, lease_owner, opts \\ []),
+    do: adapter(opts).close_shard(app_name, shard_id, lease_owner, opts)
 
   defp adapter(opts) do
     Keyword.get(opts, :adapter, KinesisClient.Stream.AppState.Dynamo)

--- a/lib/kinesis_client/stream/app_state/dynamo.ex
+++ b/lib/kinesis_client/stream/app_state/dynamo.ex
@@ -149,10 +149,10 @@ defmodule KinesisClient.Stream.AppState.Dynamo do
       return_values: "UPDATED_NEW"
     ]
 
-    case Dynamo.update_item(app_name, %{"shard_id" => shard_id}, update_opt) |> ExAws.request() do
+    case Dynamo.update_item(app_name, %{"shard_id" => shard_id}, update_opt)
+         |> ExAws.request() do
       {:ok, %{"Attributes" => %{"completed" => %{"BOOL" => true}}}} -> :ok
       {:error, {"ConditionalCheckFailedException", _}} -> {:error, :lease_owner_match}
-      reply -> reply
     end
   end
 

--- a/lib/kinesis_client/stream/app_state/dynamo.ex
+++ b/lib/kinesis_client/stream/app_state/dynamo.ex
@@ -1,5 +1,9 @@
 defmodule KinesisClient.Stream.AppState.Dynamo do
-  @moduledoc false
+  @moduledoc """
+  Adapter for using DynamoDB as the application state store (the default).
+
+  See KinesisClient.Stream.AppState for more information.
+  """
 
   alias ExAws.Dynamo
   alias KinesisClient.Stream.AppState.Adapter, as: AppStateAdapter

--- a/lib/kinesis_client/stream/app_state/dynamo.ex
+++ b/lib/kinesis_client/stream/app_state/dynamo.ex
@@ -1,8 +1,10 @@
 defmodule KinesisClient.Stream.AppState.Dynamo do
   @moduledoc false
+
+  alias ExAws.Dynamo
   alias KinesisClient.Stream.AppState.Adapter, as: AppStateAdapter
   alias KinesisClient.Stream.AppState.ShardLease
-  alias ExAws.Dynamo
+
   require Logger
 
   @behaviour AppStateAdapter

--- a/lib/kinesis_client/stream/coordinator.ex
+++ b/lib/kinesis_client/stream/coordinator.ex
@@ -72,7 +72,7 @@ defmodule KinesisClient.Stream.Coordinator do
       retry_timeout: Keyword.get(opts, :retry_timeout, 30_000)
     }
 
-    Logger.debug("Starting KinesisClient.Stream.Coordinator: #{inspect(state)}")
+    Logger.debug("[kcl_ex] Starting KinesisClient.Stream.Coordinator: #{inspect(state)}")
     {:ok, state, {:continue, :initialize}}
   end
 
@@ -132,7 +132,7 @@ defmodule KinesisClient.Stream.Coordinator do
         {:noreply, %{state | shard_graph: shard_graph, shard_pid_map: map}}
 
       {:error, reason} ->
-        Logger.info("[kcl_ex] error describing stream shards with result #{inspect(reason)}")
+        Logger.error("[kcl_ex] error describing stream shards with result #{inspect(reason)}")
 
         if state.startup_attempt < @max_startup_attempts do
           sleep_period_ms = state.retry_timeout + :rand.uniform(@jitter)
@@ -143,9 +143,7 @@ defmodule KinesisClient.Stream.Coordinator do
 
           {:noreply, state, {:continue, :describe_stream}}
         else
-          Logger.error(
-            "[kcl_ex] error starting stream coordinator after three attempts for stream #{state.stream_name}"
-          )
+          Logger.error("[kcl_ex] error starting stream coordinator after three attempts for stream #{state.stream_name}")
 
           {:stop, :normal, state}
         end
@@ -206,7 +204,7 @@ defmodule KinesisClient.Stream.Coordinator do
 
   defp maybe_start_shard(parents, shard_id, state, shard_pid_map) do
     if parents_completed?(parents, shard_id, state) and not shard_completed?(shard_id, state) do
-      Logger.info("Parent shards are complete and child is not, so starting #{shard_id}")
+      Logger.info("[kcl_ex] Parent shards are complete and child is not, so starting #{shard_id}")
 
       {:ok, shard_pid} = start_shard(shard_id, state)
       Map.put(shard_pid_map, shard_id, shard_pid)
@@ -223,7 +221,7 @@ defmodule KinesisClient.Stream.Coordinator do
         true
 
       {parent, _} ->
-        Logger.info("Parent shard #{parent} is not completed so skipping #{shard_id}")
+        Logger.info("[kcl_ex] Parent shard #{parent} is not completed so skipping #{shard_id}")
         false
     end)
   end

--- a/lib/kinesis_client/stream/shard.ex
+++ b/lib/kinesis_client/stream/shard.ex
@@ -1,5 +1,12 @@
 defmodule KinesisClient.Stream.Shard do
-  @moduledoc false
+  @moduledoc """
+  This module starts up lease management for a given shard and starts a pipeline to process
+  records from the shard, once the lease is acquired.
+
+  Some consideration could be made for combining the lease management and pipeline into a single
+  process so that state management is more centralized.
+  """
+
   use Supervisor, restart: :transient
   alias KinesisClient.Stream.Shard.{Lease, Pipeline}
   import KinesisClient.Util

--- a/lib/kinesis_client/stream/shard/lease.ex
+++ b/lib/kinesis_client/stream/shard/lease.ex
@@ -1,5 +1,13 @@
 defmodule KinesisClient.Stream.Shard.Lease do
-  @moduledoc false
+  @moduledoc """
+  This module is responsible for managing the lease for a given shard. It will attempt to take
+  the lease if it is not currently owned by another node, or renew the lease if it is owned by
+  this node.
+
+  If the lease is not renewed within a certain amount of time, it will be considered expired and
+  can be taken by another node.
+  """
+
   require Logger
   use GenServer
   alias KinesisClient.Stream.AppState

--- a/lib/kinesis_client/stream/shard/lease.ex
+++ b/lib/kinesis_client/stream/shard/lease.ex
@@ -55,7 +55,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
 
     Process.send_after(self(), :take_or_renew_lease, state.renew_interval)
 
-    Logger.debug("Starting KinesisClient.Stream.Lease: #{inspect(state)}")
+    Logger.debug("[kcl_ex] Starting KinesisClient.Stream.Lease: #{inspect(state)}")
 
     {:ok, state, {:continue, :initialize}}
   end
@@ -66,7 +66,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
       case get_lease(state) do
         :not_found ->
           Logger.debug(
-            "No existing lease record found in AppState: " <>
+            "[kcl_ex] No existing lease record found in AppState: " <>
               "[app_name: #{state.app_name}, shard_id: #{state.shard_id}]"
           )
 
@@ -95,7 +95,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
           {:noreply, take_or_renew_lease(s, state)}
 
         {:error, e} ->
-          Logger.error("Error fetching shard #{state.share_id}: #{inspect(e)}")
+          Logger.error("[kcl_ex] Error fetching shard #{state.share_id}: #{inspect(e)}")
           {:noreply, state}
       end
 
@@ -122,7 +122,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
           end
 
         Logger.debug(
-          "Lease is owned by another node, and could not be taken: [shard_id: #{state.shard_id}, " <>
+          "[kcl_ex] Lease is owned by another node, and could not be taken: [shard_id: #{state.shard_id}, " <>
             "lease_owner: #{state.lease_owner}, lease_count: #{state.lease_count}]"
         )
 
@@ -147,7 +147,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
   @spec create_lease(state :: t()) :: t()
   defp create_lease(%{app_state_opts: opts, app_name: app_name, lease_owner: lease_owner} = state) do
     Logger.debug(
-      "Creating lease: [app_name: #{app_name}, shard_id: #{state.shard_id}, lease_owner: " <>
+      "[kcl_ex] Creating lease: [app_name: #{app_name}, shard_id: #{state.shard_id}, lease_owner: " <>
         "#{lease_owner}]"
     )
 
@@ -162,7 +162,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
     expected = shard_lease.lease_count + 1
 
     Logger.debug(
-      "Renewing lease: [app_name: #{app_name}, shard_id: #{state.shard_id}, lease_owner: " <>
+      "[kcl_ex] Renewing lease: [app_name: #{app_name}, shard_id: #{state.shard_id}, lease_owner: " <>
         "#{state.lease_owner}]"
     )
 
@@ -174,7 +174,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
 
       {:error, :lease_renew_failed} ->
         Logger.debug(
-          "Failed to renew lease, stopping producer: [app_name: #{app_name}, " <>
+          "[kcl_ex] Failed to renew lease, stopping producer: [app_name: #{app_name}, " <>
             "shard_id: #{state.shard_id}, lease_owner: #{state.lease_owner}]"
         )
 
@@ -182,7 +182,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
         %{state | lease_holder: false, lease_count_increment_time: current_time()}
 
       {:error, e} ->
-        Logger.error("Error trying to renew lease for #{state.shard_id}: #{inspect(e)}")
+        Logger.error("[kcl_ex] Error trying to renew lease for #{state.shard_id}: #{inspect(e)}")
         state
     end
   end
@@ -191,7 +191,7 @@ defmodule KinesisClient.Stream.Shard.Lease do
     expected = state.lease_count + 1
 
     Logger.debug(
-      "Attempting to take lease: [lease_owner: #{state.lease_owner}, shard_id: #{state.shard_id}]"
+      "[kcl_ex] Attempting to take lease: [lease_owner: #{state.lease_owner}, shard_id: #{state.shard_id}]"
     )
 
     case AppState.take_lease(app_name, state.shard_id, state.lease_owner, state.lease_count, opts) do

--- a/lib/kinesis_client/stream/shard/pipeline.ex
+++ b/lib/kinesis_client/stream/shard/pipeline.ex
@@ -55,6 +55,10 @@ defmodule KinesisClient.Stream.Shard.Pipeline do
 
     pipeline_opts = [
       name: name(opts[:app_name], opts[:shard_id]),
+      # 5 minutes was the default behavior for kcl_ex, previously
+      # handled using Process.send_after.
+      # This ensures shard split/merges finish processing messages.
+      shutdown: :timer.minutes(5),
       producer: [
         module: {Producer, producer_opts},
         concurrency: 1

--- a/lib/kinesis_client/stream/shard/pipeline.ex
+++ b/lib/kinesis_client/stream/shard/pipeline.ex
@@ -1,5 +1,13 @@
 defmodule KinesisClient.Stream.Shard.Pipeline do
-  @moduledoc false
+  @moduledoc """
+  This module is responsible for managing the pipeline for a given shard. It will start a
+  Broadway pipeline to process records from the shard. The producer of that pipeline
+  still expects a shard lease to be acquired before it will start processing records.
+
+  The pipeline's producer starts with a status of `:stopped` and will not start processing
+  records until it receives a `:start` message. This message is sent by the shard lease
+  process when it has acquired the lease.
+  """
   use Broadway
   import KinesisClient.Util
   alias KinesisClient.Stream.Shard.Producer

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -68,7 +68,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
 
     :telemetry.execute([:kinesis_client, :shard_producer, :started], %{}, telemetry_meta(state))
 
-    Logger.debug("Starting KinesisClient.Stream.Shard.Producer: #{inspect(state)}")
+    Logger.debug("[kcl_ex] Starting KinesisClient.Stream.Shard.Producer: #{inspect(state)}")
     {:producer, state}
   end
 
@@ -82,19 +82,19 @@ defmodule KinesisClient.Stream.Shard.Producer do
 
   @impl GenStage
   def handle_demand(_, %{demand: demand, status: :closed} = state) do
-    Logger.info("Shard is closed, not storing demand")
+    Logger.info("[kcl_ex] Shard is closed, not storing demand")
     {:noreply, [], %{state | demand: demand}}
   end
 
   @impl GenStage
   def handle_demand(incoming_demand, %{demand: demand} = state) do
-    Logger.debug("Received incoming demand: #{incoming_demand}")
+    Logger.debug("[kcl_ex] Received incoming demand: #{incoming_demand}")
     get_records(%{state | demand: demand + incoming_demand})
   end
 
   @impl GenStage
   def handle_info(:get_records, %{poll_timer: nil} = state) do
-    Logger.debug("Poll timer is nil")
+    Logger.debug("[kcl_ex] Poll timer is nil")
     {:noreply, [], state}
   end
 
@@ -103,7 +103,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
     notify(:poll_timer_executed, state)
 
     Logger.debug(
-      "Try to fulfill pending demand #{state.demand}: " <>
+      "[kcl_ex] Try to fulfill pending demand #{state.demand}: " <>
         "[app_name: #{state.app_name}, shard_id: #{state.shard_id}]"
     )
 
@@ -115,7 +115,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
         %{coordinator_name: coordinator, shard_id: shard_id, child_shards: child_shards} = state
       ) do
     Logger.info(
-      "Shard is closed, notifying Coordinator: [app_name: #{state.app_name}, " <>
+      "[kcl_ex] Shard is closed, notifying Coordinator: [app_name: #{state.app_name}, " <>
         "shard_id: #{state.shard_id}]"
     )
 
@@ -149,7 +149,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
       :ok = update_checkpoint(state, checkpoint)
     else
       Logger.warn("""
-        Unable to update checkpoint for app_name: #{state.app_name}, shard_id: #{state.shard_id}
+        [kcl_ex] Unable to update checkpoint for app_name: #{state.app_name}, shard_id: #{state.shard_id}
 
         This might happen for a few reasons (in order of likelihood):
         1. You are writing tests, and your messages need something like %{metadata: %{"SequenceNumber" => "SomeStringHere"}}
@@ -168,14 +168,12 @@ defmodule KinesisClient.Stream.Shard.Producer do
         "shard_id: #{state.shard_id}"
     )
 
-    # state = handle_closed_shard(state)
-
     {:noreply, [], state}
   end
 
   @impl GenStage
   def handle_info(msg, state) do
-    Logger.debug("#{__MODULE__} got an unhandled message #{inspect(msg)}")
+    Logger.debug("[kcl_ex] #{__MODULE__} got an unhandled message #{inspect(msg)}")
     {:noreply, [], state}
   end
 
@@ -304,7 +302,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
          "Records" => records
        }} ->
         Logger.debug(
-          "Received #{length(records)} records (#{millis_behind_latest} ms behind latest) for #{state.app_name}-#{state.shard_id}"
+          "[kcl_ex] Received #{length(records)} records (#{millis_behind_latest} ms behind latest) for #{state.app_name}-#{state.shard_id}"
         )
 
         new_demand = demand - length(records)
@@ -343,7 +341,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
 
       {:ok, %{"ChildShards" => child_shards, "MillisBehindLatest" => _, "Records" => []}} ->
         Logger.debug(
-          "Shard #{state.shard_id} has child shards: #{inspect(child_shards)} - the current shard will now close"
+          "[kcl_ex] Shard #{state.shard_id} has child shards: #{inspect(child_shards)} - the current shard will now close"
         )
 
         state = handle_closed_shard(%{state | child_shards: child_shards})
@@ -352,7 +350,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
 
       {:error, reason} ->
         Logger.info(
-          "Received error when getting records for #{state.app_name}-#{state.shard_id}: #{inspect(reason)}"
+          "[kcl_ex] Received error when getting records for #{state.app_name}-#{state.shard_id}: #{inspect(reason)}"
         )
 
         :telemetry.execute(

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -168,12 +168,9 @@ defmodule KinesisClient.Stream.Shard.Producer do
         "shard_id: #{state.shard_id}"
     )
 
-    if state.status == :closed do
-      state = handle_closed_shard(state)
-      {:noreply, [], state}
-    else
-      {:noreply, [], state}
-    end
+    # state = handle_closed_shard(state)
+
+    {:noreply, [], state}
   end
 
   @impl GenStage
@@ -228,12 +225,8 @@ defmodule KinesisClient.Stream.Shard.Producer do
 
     GenStage.reply(from, :ok)
 
-    if new_state.status == :closed do
-      new_state = handle_closed_shard(new_state)
-      {:noreply, records, new_state}
-    else
-      {:noreply, records, new_state}
-    end
+    # new_state = handle_closed_shard(new_state)
+    {:noreply, records, new_state}
   end
 
   @impl GenStage

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -1,6 +1,12 @@
 defmodule KinesisClient.Stream.Shard.Producer do
   @moduledoc """
   Producer GenStage used in `KinesisClient.Stream.ShardConsumer` Broadway pipeline.
+
+  Messages for the Kinesis shard are retrieved here and sent to the consumer. Once
+  the Producer consumes the last records of a given Stream, AWS returns the child
+  shards that continue the Stream for this shard. The Producer then notifies the
+  Coordinator of the child shards so that they can be added to the Stream, and
+  then the Producer signals for the shard to be stopped.
   """
   use GenStage
   require Logger

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -13,7 +13,6 @@ defmodule KinesisClient.Stream.Shard.Producer do
   alias KinesisClient.Kinesis
   alias KinesisClient.Stream.AppState
   alias KinesisClient.Stream.Coordinator
-  alias KinesisClient.Stream.Shard
   @behaviour Broadway.Producer
 
   defstruct [
@@ -119,18 +118,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
         "shard_id: #{state.shard_id}]"
     )
 
-    :ok =
-      AppState.close_shard(
-        state.app_name,
-        shard_id,
-        state.lease_owner,
-        state.app_state_opts
-      )
-
-    :ok = Coordinator.append_shards(coordinator, child_shards)
-
-    Shard.name(state.app_name, state.stream_name, shard_id)
-    |> Shard.stop()
+    :ok = Coordinator.continue_shard_with_children(coordinator, shard_id, child_shards)
 
     {:noreply, [], %{state | status: :closed}}
   end

--- a/test/kinesis_client/stream/app_state/dynamo_test.exs
+++ b/test/kinesis_client/stream/app_state/dynamo_test.exs
@@ -1,9 +1,9 @@
 defmodule KinesisClient.Stream.AppState.DynamoTest do
   use KinesisClient.Case
 
+  alias ExAws.Dynamo
   alias KinesisClient.Stream.AppState.Dynamo, as: AppState
   alias KinesisClient.Stream.AppState.ShardLease
-  alias ExAws.Dynamo
 
   setup_all do
     app_name = "foo_app_#{random_string()}"

--- a/test/kinesis_client/stream/app_state/shard_lease_test.exs
+++ b/test/kinesis_client/stream/app_state/shard_lease_test.exs
@@ -1,8 +1,8 @@
 defmodule KinesisClient.Stream.AppState.ShardLeaseTest do
   use KinesisClient.Case
 
-  alias KinesisClient.Stream.AppState.ShardLease
   alias ExAws.Dynamo.Encodable
+  alias KinesisClient.Stream.AppState.ShardLease
 
   test "ExAws.Dynamo.Encodable.encode/2 implemented" do
     result = Encodable.encode(%ShardLease{}, [])

--- a/test/kinesis_client/stream/coordinator_test.exs
+++ b/test/kinesis_client/stream/coordinator_test.exs
@@ -116,6 +116,8 @@ defmodule KinesisClient.Stream.CoordinatorTest do
     {:ok, _} = start_coordinator(opts)
 
     assert_receive {:shards, shards}, 5_000
+    assert Enum.empty?(shards) == false
+
     assert_receive {:shard_started, %{pid: pid, shard_id: "shardId-000000000000"}}, 5_000
     assert Process.alive?(pid) == true
     assert_receive {:shard_started, %{pid: pid, shard_id: "shardId-000000000001"}}, 5_000
@@ -123,8 +125,6 @@ defmodule KinesisClient.Stream.CoordinatorTest do
 
     refute_receive {:shard_started, %{pid: _, shard_id: "shardId-000000000002"}}, 5_000
     refute_receive {:shard_started, %{pid: _, shard_id: "shardId-000000000003"}}, 5_000
-
-    assert Enum.empty?(shards) == false
   end
 
   @tag capture_log: true

--- a/test/kinesis_client/stream/coordinator_test.exs
+++ b/test/kinesis_client/stream/coordinator_test.exs
@@ -1,8 +1,9 @@
 defmodule KinesisClient.Stream.CoordinatorTest do
   use KinesisClient.Case, async: false
 
-  alias KinesisClient.Stream.Coordinator
   alias KinesisClient.Stream.AppState.ShardLease
+  alias KinesisClient.Stream.Coordinator
+
   @stream_name "decline-roman-empire-test"
   @shard_count 6
   @supervisor_name MyShardSupervisor

--- a/test/kinesis_client/stream/shard/lease_test.exs
+++ b/test/kinesis_client/stream/shard/lease_test.exs
@@ -1,8 +1,8 @@
 defmodule KinesisClient.Stream.Shard.LeaseTest do
   use KinesisClient.Case
 
-  alias KinesisClient.Stream.Shard.Lease
   alias KinesisClient.Stream.AppState.ShardLease
+  alias KinesisClient.Stream.Shard.Lease
 
   # TODO This test is failing for as yet unclear reasons
   # Blocking it out for now

--- a/test/kinesis_client/stream/shard/lease_test.exs
+++ b/test/kinesis_client/stream/shard/lease_test.exs
@@ -123,7 +123,7 @@ defmodule KinesisClient.Stream.Shard.LeaseTest do
       {:ok, lc + 1}
     end)
 
-    {:ok, pid} = start_supervised({Lease, lease_opts})
+    {:ok, _pid} = start_supervised({Lease, lease_opts})
 
     assert_receive {:initialized, %{lease_count_increment_time: lcit} = lease_state}, 1_000
     assert lease_state.lease_holder == false
@@ -132,7 +132,7 @@ defmodule KinesisClient.Stream.Shard.LeaseTest do
     assert_receive {:tracking_lease, _}, 5_000
     assert_receive {:lease_taken, lease_state}, 15_000
 
-    stop_supervised(pid)
+    stop_supervised(Lease)
     assert lease_state.lease_holder == true
     assert lease_state.lease_count == shard_lease.lease_count + 1
     assert lcit < lease_state.lease_count_increment_time
@@ -148,7 +148,7 @@ defmodule KinesisClient.Stream.Shard.LeaseTest do
       shard_lease
     end)
 
-    {:ok, pid} = start_supervised({Lease, lease_opts})
+    {:ok, _pid} = start_supervised({Lease, lease_opts})
 
     assert_receive {:initialized, %{lease_count_increment_time: _lcit} = lease_state}, 1_000
     assert lease_state.lease_holder == false
@@ -158,7 +158,7 @@ defmodule KinesisClient.Stream.Shard.LeaseTest do
     assert lease_state.lease_count == shard_lease.lease_count
 
     assert_receive {:tracking_lease, lease_state}, 5_000
-    stop_supervised(pid)
+    stop_supervised(Lease)
     assert lease_state.lease_holder == false
     assert lease_state.lease_count == shard_lease.lease_count
   end

--- a/test/kinesis_client/stream/shard/pipeline_test.exs
+++ b/test/kinesis_client/stream/shard/pipeline_test.exs
@@ -1,8 +1,8 @@
 defmodule KinesisClient.Stream.Shard.PipelineTest do
   use KinesisClient.Case, async: false
 
-  alias KinesisClient.Stream.Shard.Pipeline
   alias KinesisClient.Stream.AppState.ShardLease
+  alias KinesisClient.Stream.Shard.Pipeline
 
   test "can start producer" do
     app_name = "sdf9023kl"

--- a/test/kinesis_client/stream/shard/producer_test.exs
+++ b/test/kinesis_client/stream/shard/producer_test.exs
@@ -230,7 +230,7 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
   describe "get_top_checkpoint/2" do
     test "sorts sequence numbers correctly" do
       assert "12345+10" =
-               KinesisClient.Stream.Shard.Producer.get_top_checkpoint(
+               Producer.get_top_checkpoint(
                  [%{metadata: %{"SequenceNumber" => "12345+1"}}],
                  [%{metadata: %{"SequenceNumber" => "12345+10"}}]
                )
@@ -238,7 +238,7 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
 
     test "returns -1 for incorrectly-formatted messages" do
       assert "12345+5" =
-               KinesisClient.Stream.Shard.Producer.get_top_checkpoint(
+               Producer.get_top_checkpoint(
                  [%{mettadatums: %{"SequenceWhat?" => "12345+1"}}],
                  [
                    %{metaverse: %{"NotConforming" => "12345+10"}},
@@ -249,7 +249,7 @@ defmodule KinesisClient.Stream.Shard.ProducerTest do
 
     test "returns -1 for empty lists" do
       assert "-1" =
-               KinesisClient.Stream.Shard.Producer.get_top_checkpoint(
+               Producer.get_top_checkpoint(
                  [],
                  []
                )

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -1,4 +1,5 @@
 defmodule KinesisClient.Case do
+  @moduledoc false
   use ExUnit.CaseTemplate
   import Mox
 

--- a/test/support/kinesis_responses.ex
+++ b/test/support/kinesis_responses.ex
@@ -1,4 +1,5 @@
 defmodule KinesisClient.KinesisResponses do
+  @moduledoc false
   def shard_object do
     %{
       "HashKeyRange" => %{

--- a/test/support/test_shard_consumer.ex
+++ b/test/support/test_shard_consumer.ex
@@ -1,4 +1,5 @@
 defmodule KinesisClient.TestShardConsumer do
+  @moduledoc false
   @behaviour Broadway
 
   @impl Broadway

--- a/test/support/test_stream.ex
+++ b/test/support/test_stream.ex
@@ -1,4 +1,5 @@
 defmodule KinesisClient.TestStream do
+  @moduledoc false
   alias ExAws.Kinesis
 
   def describe_stream(_stream_name) do

--- a/test/support/test_util.ex
+++ b/test/support/test_util.ex
@@ -1,4 +1,5 @@
 defmodule KinesisClient.TestUtil do
+  @moduledoc false
   def random_string do
     min = String.to_integer("10000000", 36)
     max = String.to_integer("ZZZZZZZZ", 36)
@@ -10,7 +11,7 @@ defmodule KinesisClient.TestUtil do
     |> Integer.to_string(36)
   end
 
-  def worker_ref() do
+  def worker_ref do
     "worker-#{:rand.uniform(10_000)}"
   end
 end


### PR DESCRIPTION
**New features:**
* More standardized logging
* Shard split/merge support
* When a shard completes, new child shard(s) don’t start until the old parent shard has fully shut down. This includes waiting for Broadway to finish doing Broadway stuff. More information on how Broadway handles this here: https://hexdocs.pm/broadway/architecture.html#graceful-shutdowns

**Stuff we could still do:**
* Make it so we randomly assign shards to nodes running in our cluster, so we don’t “hotspot”. Under the current design, if we split a shard, both child shards will end up on the shard that hosted the parent. Without a release or circuitbreaker flip, regular shard splits will eventually exhaust a given pod.
* More telemetry events for everything going on in kcl_ex
* More test coverage