### PR TITLE
feat(pla-286): add can_acquire_lease callback

### DIFF
--- a/lib/kinesis_client/stream.ex
+++ b/lib/kinesis_client/stream.ex
@@ -23,6 +23,8 @@ defmodule KinesisClient.Stream do
     * `:lease_expiry`(optional) - The lenght of time in milliseconds that least lasts for. If a
       lease is not renewed within this time frame, then that lease is considered expired and can be
       taken by another process. Defaults to 90 seconds.
+    * `:can_acquire_lease?` - A function that determines if a lease can be acquired. The function
+      should take a single argument, the shard_id, and return a boolean. Defaults to `fn _ -> true end`.
   """
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
@@ -52,6 +54,7 @@ defmodule KinesisClient.Stream do
       |> optional_kw(:app_state_opts, Keyword.get(opts, :app_state_opts))
       |> optional_kw(:lease_renew_interval, Keyword.get(opts, :lease_renew_interval))
       |> optional_kw(:lease_expiry, Keyword.get(opts, :lease_expiry))
+      |> optional_kw(:can_acquire_lease?, Keyword.get(opts, :can_acquire_lease?))
 
     coordinator_args = [
       name: coordinator_name,

--- a/lib/kinesis_client/stream/shard.ex
+++ b/lib/kinesis_client/stream/shard.ex
@@ -39,6 +39,7 @@ defmodule KinesisClient.Stream.Shard do
       |> optional_kw(:app_state_opts, Keyword.get(opts, :app_state_opts))
       |> optional_kw(:renew_interval, Keyword.get(opts, :lease_renew_interval))
       |> optional_kw(:lease_expiry, Keyword.get(opts, :lease_expiry))
+      |> optional_kw(:can_acquire_lease?, Keyword.get(opts, :can_acquire_lease?))
 
     children = [
       {Lease, lease_opts},

--- a/lib/kinesis_client/stream/shard/producer.ex
+++ b/lib/kinesis_client/stream/shard/producer.ex
@@ -142,7 +142,7 @@ defmodule KinesisClient.Stream.Shard.Producer do
     if checkpoint != "-1" do
       :ok = update_checkpoint(state, checkpoint)
     else
-      Logger.warn("""
+      Logger.warning("""
         [kcl_ex] Unable to update checkpoint for app_name: #{state.app_name}, shard_id: #{state.shard_id}, stream_name: #{state.stream_name}
 
         This might happen for a few reasons (in order of likelihood):

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -15,6 +15,6 @@ Application.put_env(:ex_aws, :kinesis,
   region: "us-east-1"
 )
 
-Logger.configure(level: :warn)
+Logger.configure(level: :warning)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
This callback is checked before attempting to take or renew a lease. If it returns true (the default), we proceed as normal. If it returns false, then no lease acquisition or renewal is attempted, and any running pipelines are halted.

We will use this hook to determine if the currently running pod ought to be running the given shard, the idea being that we can convert the list of running pods into a hash ring, hash the shard id, and determine which pod ought to have the lease.

In production, we will cache the k8s replicaset information so that this lease acquisition check is very fast, and put the whole thing behind a feature flag so we can roll this out incrementally.