### PR TITLE
chore(pla-286): rollback behavior change

### DIFF
--- a/lib/kinesis_client/stream/shard/lease.ex
+++ b/lib/kinesis_client/stream/shard/lease.ex
@@ -228,11 +228,13 @@ defmodule KinesisClient.Stream.Shard.Lease do
           state
 
         {:error, :lease_take_failed} ->
-          :ok = Pipeline.stop(app_name, state.shard_id)
+          # TODO
+          # :ok = Processor.ensure_halted(state)
           %{state | lease_holder: false, lease_count_increment_time: current_time()}
       end
     else
-      :ok = Pipeline.stop(app_name, state.shard_id)
+      # TODO
+      # :ok = Processor.ensure_halted(state)
       %{state | lease_holder: false, lease_count_increment_time: current_time()}
     end
   end


### PR DESCRIPTION
This is rolling back a behavior change that I introduced in the previous release of kcl_ex. Previously, when we fail to acquire a lease, we would do nothing. I introduced an assumeed fix for behavior, however it is possible that messed up monitoring Kinesis pipelines.