### PR TITLE
fix(pla-354): fix stop regression

### DIFF
--- a/lib/kinesis_client/stream/shard/pipeline.ex
+++ b/lib/kinesis_client/stream/shard/pipeline.ex
@@ -77,7 +77,13 @@ defmodule KinesisClient.Stream.Shard.Pipeline do
     names = Broadway.producer_names(name(app_name, shard_id))
 
     errors =
-      Enum.reduce(names, [], fn name, errs ->
+      names
+      |> Enum.reject(fn name ->
+        name
+        |> Process.whereis()
+        |> is_nil()
+      end)
+      |> Enum.reduce([], fn name, errs ->
         case Producer.start(name) do
           :ok ->
             errs
@@ -97,9 +103,18 @@ defmodule KinesisClient.Stream.Shard.Pipeline do
     names = Broadway.producer_names(name(app_name, shard_id))
 
     errors =
-      Enum.reduce(names, [], fn name, errs ->
+      names
+      |> Enum.reject(fn name ->
+        name
+        |> Process.whereis()
+        |> is_nil()
+      end)
+      |> Enum.reduce([], fn name, errs ->
         case Producer.stop(name) do
           :ok ->
+            errs
+
+          {:error, :not_found} ->
             errs
 
           other ->

--- a/lib/kinesis_client/stream/shard/pipeline.ex
+++ b/lib/kinesis_client/stream/shard/pipeline.ex
@@ -114,9 +114,6 @@ defmodule KinesisClient.Stream.Shard.Pipeline do
           :ok ->
             errs
 
-          {:error, :not_found} ->
-            errs
-
           other ->
             [other | errs]
         end


### PR DESCRIPTION
Previously, we never attempted to stop the pipeline if the lease was dropped for some reason.

Now that we attempt to do this, we're seeing errors & pipeline crashes.

This fixes that, by no-oping stops or starts when the pipeline is already started/stopped.