### PR TITLE
fix: correct field name in stream coordinator

### DIFF
--- a/lib/kinesis_client/stream.ex
+++ b/lib/kinesis_client/stream.ex
@@ -44,7 +44,7 @@ defmodule KinesisClient.Stream do
     {shard_supervisor_spec, shard_supervisor_name} = get_shard_supervisor(opts)
     coordinator_name = get_coordinator_name(opts)
     shard_consumer = get_shard_consumer(opts)
-    retry_timeout = Keyword.get(opts, :retry_timeout, 30_000)
+    retry_timeout = Keyword.get(opts, :rate_limited_retry_timeout, 30_000)
     retry_jitter = Keyword.get(opts, :rate_limited_retry_jitter, 5_000)
 
     shard_args = [

--- a/lib/kinesis_client/stream/coordinator.ex
+++ b/lib/kinesis_client/stream/coordinator.ex
@@ -173,7 +173,7 @@ defmodule KinesisClient.Stream.Coordinator do
         {:noreply, %{state | shard_graph: shard_graph, shard_pid_map: map}}
 
       {:error, {"LimitExceededException", _}} ->
-        sleep_period_ms = state.retry_timeout + :rand.uniform(state.jitter)
+        sleep_period_ms = state.retry_timeout + :rand.uniform(state.retry_jitter)
 
         Logger.error(
           "[kcl_ex] error describing stream #{state.stream_name} shards due to limit exceeded: Retrying in #{sleep_period_ms} ms"
@@ -191,7 +191,7 @@ defmodule KinesisClient.Stream.Coordinator do
         )
 
         if state.startup_attempt < @max_startup_attempts do
-          sleep_period_ms = state.retry_timeout + :rand.uniform(state.jitter)
+          sleep_period_ms = state.retry_timeout + :rand.uniform(state.retry_jitter)
           :timer.sleep(sleep_period_ms)
 
           state = %{state | startup_attempt: state.startup_attempt + 1}


### PR DESCRIPTION
This fixes the regressions we saw when we deployed `master` yesterday. Once this is merged in, I'll also rebase `master` on the branch currently in production (the one which removes Hackney) and deploy.