### PR TITLE
fix(pla-2261): allow tuning KinesisClient.Stream.Shard.Producer poll_interval option

### DIFF
--- a/lib/kinesis_client/stream.ex
+++ b/lib/kinesis_client/stream.ex
@@ -59,6 +59,7 @@ defmodule KinesisClient.Stream do
       shard_consumer: shard_consumer,
       processors: opts[:processors],
       batchers: opts[:batchers],
+      producer_poll_interval: opts[:producer_poll_interval],
       shard_producer_shutdown_timeout: shard_producer_shutdown_timeout
     ]
 

--- a/lib/kinesis_client/stream/shard.ex
+++ b/lib/kinesis_client/stream/shard.ex
@@ -32,6 +32,7 @@ defmodule KinesisClient.Stream.Shard do
       shard_consumer: opts[:shard_consumer],
       processors: opts[:processors],
       batchers: opts[:batchers],
+      producer_poll_interval: opts[:producer_poll_interval],
       coordinator_name: opts[:coordinator_name]
     ]
 

--- a/lib/kinesis_client/stream/shard/pipeline.ex
+++ b/lib/kinesis_client/stream/shard/pipeline.ex
@@ -21,7 +21,7 @@ defmodule KinesisClient.Stream.Shard.Pipeline do
       stream_name: opts[:stream_name],
       kinesis_opts: Keyword.get(opts, :kinesis_opts, []),
       app_state_opts: Keyword.get(opts, :app_state_opts, []),
-      poll_interval: Keyword.get(opts, :poll_interval, 5_000),
+      poll_interval: Keyword.get(opts, :producer_poll_interval, 5_000),
       coordinator_name: opts[:coordinator_name],
       status: :stopped
     ]


### PR DESCRIPTION
We need to ingest the option from `KinesisClient.Stream` and pass it thru the supervision tree to allow tuning it.